### PR TITLE
fix: base-url-aware asset paths so Pages deploy renders 🐛

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -3,7 +3,7 @@ title = "About"
 template = "section.html"
 
 [extra]
-banner = "/images/banner/about.png"
+banner = "images/banner/about.png"
 hide_title = true
 +++
 

--- a/content/crew/_index.md
+++ b/content/crew/_index.md
@@ -11,7 +11,7 @@ delegate to the right hand.
 <div class="crew-grid">
 
 <div class="crew-card">
-  <img class="crew-portrait" src="/images/crew/maren.png" alt="Maren, the Shipwright" loading="lazy">
+  {{ crew_portrait(src="images/crew/maren.png", alt="Maren, the Shipwright") }}
   <div class="crew-rank">Shipwright</div>
   <h3>Maren</h3>
   <p class="crew-voice">British English &middot; <code>en_GB-cori-high</code></p>
@@ -29,7 +29,7 @@ delegate to the right hand.
 </div>
 
 <div class="crew-card">
-  <img class="crew-portrait" src="/images/crew/crest.png" alt="Crest, the Signalman" loading="lazy">
+  {{ crew_portrait(src="images/crew/crest.png", alt="Crest, the Signalman") }}
   <div class="crew-rank">Signalman</div>
   <h3>Crest</h3>
   <p class="crew-voice">US English &middot; <code>en_US-lessac-high</code></p>

--- a/content/roadmap/_index.md
+++ b/content/roadmap/_index.md
@@ -3,7 +3,7 @@ title = "The Voyage"
 template = "section.html"
 
 [extra]
-banner = "/images/banner/voyage.png"
+banner = "images/banner/voyage.png"
 +++
 
 The fleet sails in milestones. Each milestone is a leg of the voyage &mdash;

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -167,7 +167,7 @@ table {
   position: absolute;
   inset: 0 0 -360px 0;
   z-index: 0;
-  background: url('/images/hero/sunset-bridge.png') center top / cover no-repeat;
+  background: url('images/hero/sunset-bridge.png') center top / cover no-repeat;
   will-change: transform;
   transform: translateZ(0); // promote to its own layer for smooth compositing
 }
@@ -629,7 +629,7 @@ table {
 .footer-strip-bg {
   position: absolute;
   inset: 0 0 -120px 0;
-  background-image: url('/images/texture/horizon-strip.png');
+  background-image: url('images/texture/horizon-strip.png');
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;

--- a/templates/section.html
+++ b/templates/section.html
@@ -5,7 +5,7 @@
 {% block content %}
 {% if section.extra.banner %}
 <div class="section-banner{% if section.extra.overlap_banner %} section-banner--overlap{% endif %}" role="presentation">
-  <div class="section-banner-bg" style="background-image: url('{{ section.extra.banner }}');" data-parallax="0.35" data-parallax-max="180"></div>
+  <div class="section-banner-bg" style="background-image: url('{{ get_url(path=section.extra.banner) }}');" data-parallax="0.35" data-parallax-max="180"></div>
 </div>
 {% endif %}
 <section class="page-section{% if section.extra.overlap_banner %} page-section--overlap{% endif %}">

--- a/templates/shortcodes/crew_portrait.html
+++ b/templates/shortcodes/crew_portrait.html
@@ -1,0 +1,6 @@
+{# Crew portrait — base_url-aware <img>. Use from markdown:
+     {{ crew_portrait(src="images/crew/maren.png", alt="Maren, the Shipwright") }}
+   `src` should be relative to the static/ directory (no leading slash).
+   `get_url()` resolves through Zola's base_url so the rendered tag
+   stays correct under root and subpath deploys alike. #}
+<img class="crew-portrait" src="{{ get_url(path=src) }}" alt="{{ alt }}" loading="lazy">


### PR DESCRIPTION
PNG assets were 404'ing on the Pages deploy (subpath `/chart-house/`) while rendering fine under local `zola serve` (root). Three sources used absolute-from-root paths (`/images/...`) which the browser resolved to `https://klazomenai.github.io/images/...` rather than `https://klazomenai.github.io/chart-house/images/...`.

## What changed

- **`sass/style.scss`** (lines 170, 632): dropped leading slash on the two `url('/images/...')` calls. CSS-relative URL resolution from `/chart-house/style.css` produces `/chart-house/images/...` — correct on both subpath and root deploys.
- **`content/about/_index.md` + `content/roadmap/_index.md`**: dropped leading slash from the `banner = "/images/banner/..."` front-matter. Updated `templates/section.html` to wrap the banner path in `{{ get_url(path=...) }}` — produces full base_url-aware absolute URLs.
- **`content/crew/_index.md`**: replaced raw `<img src="/images/crew/...">` tags with a new `{{ crew_portrait(...) }}` shortcode. Added `templates/shortcodes/crew_portrait.html` that calls `get_url()` on the `src` argument. Tera doesn't run on markdown bodies; a shortcode is the only Zola-native way to base_url-template a value inside markdown.

## Why these fixes are stack-portable

All three patterns Just Work under both:
- Current Pages subpath deploy at `/chart-house/`
- Eventual custom domain `chart-house.klazomenai.dev` (Phase 4) at root

When Phase 4 lands, no further asset-path changes needed.

## Local smoke-test

```
result/style.css            → url("images/hero/sunset-bridge.png") ✓
result/about/index.html     → url(https://klazomenai.github.io/chart-house/images/banner/about.png) ✓
result/crew/index.html      → src=https://klazomenai.github.io/chart-house/images/crew/maren.png ✓
zola check --skip-external-links: 0 issues, 7ms ✓
```

## Acceptance criteria from #3

- [x] All three sources of `/images/...` absolute paths fixed
- [x] Local `nix build .#default` builds cleanly
- [x] `zola check --skip-external-links` passes (0 internal-link issues)
- [ ] All four pages render images on Pages deploy (verifiable post-merge)
- [ ] No 404s in browser dev-tools network tab on a page load (verifiable post-deploy)
- [ ] Future custom-domain deploy needs no further asset-path changes (verifiable Phase 4)

## Squash-commit subject

`fix: base-url-aware asset paths so Pages deploy renders 🐛`

Refs #3
