### PR TITLE
chore(ci): scrub the deck — clear CI deprecation noise 🏗️

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Affected here: actions/checkout,
+# DeterminateSystems/nix-installer-action. Drop this env once those bump
+# to Node-24-native versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -15,8 +22,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: actionlint
         # Sourced from the flake's pinned nixpkgs (see flake.lock).
@@ -30,8 +35,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Link check (internal links + anchors)
         # Zola's built-in checker. --skip-external-links keeps CI fast

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,6 +17,14 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# Opt into Node 24 ahead of GitHub's forced migration on 2026-06-02 (Node
+# 20 actions removed entirely 2026-09-16). Affected here: actions/checkout,
+# DeterminateSystems/nix-installer-action, actions/upload-pages-artifact,
+# actions/deploy-pages. Drop this env once those bump to Node-24-native
+# versions and we update them deliberately.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -27,8 +35,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v14
-
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Build Zola site
         run: nix build .#default --print-build-logs


### PR DESCRIPTION
Routine deck-scrubbing. Clears two cosmetic CI annotations from every chart-house run.

## What changed

- **`.github/workflows/ci.yml`**: dropped `DeterminateSystems/magic-nix-cache-action@v8` from both `lint` and `build` jobs; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow env level.
- **`.github/workflows/deploy-pages.yml`**: same two changes.

## Why

- `magic-nix-cache-action@v8` throws a `failure`-level FlakeHub auth annotation that *looks* like a build failure to anyone scanning the run summary. False alarm — the job continues without cache — but it erodes signal quality. Drop > register > migrate, given chart-house's solo-scale CI doesn't really need the ~30s cache speedup.
- Node 20 actions (`actions/checkout`, `DeterminateSystems/nix-installer-action`, `actions/upload-pages-artifact`, `actions/deploy-pages`) are forced to Node 24 starting 2026-06-02 and removed 2026-09-16. The env var opts in early — future-safe — drops cleanly when upstreams ship Node-24-native versions.

## Local smoke-test

```
nix develop --command actionlint -color   → clean
nix build .#default                       → green
```

Both workflows lint clean under the flake-pinned actionlint.

## Acceptance criteria from #5

- [x] Drop `magic-nix-cache-action@v8` from both workflows
- [x] Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow env level on both
- [x] CI run on the merge commit shows zero `failure`-level annotations *(verifiable post-merge)*
- [x] Node 20 deprecation warning resolved *(verifiable post-merge)*
- [x] Both workflows still pass; live site at https://klazomenai.github.io/chart-house/ still serves all four pages with images *(verifiable post-deploy)*

## Risk factors

- Without Nix cache, first-time tool installs add ~30s to each Nix-using job. Acceptable trade for clean run output.
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` is documented (GitHub blog post 2025-09-19). If an action breaks under Node 24, drop the env var and stay on Node 20 until 2026-06-02, then revisit.

## Squash-commit subject

`chore(ci): scrub the deck — clear CI deprecation noise 🏗️`

Refs #5
